### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/upgrade_wazuh.py
+++ b/upgrade_wazuh.py
@@ -200,7 +200,10 @@ def run_command(command, ignore_errors=False, retries=3):
     """
     try:
         sanitized_command = sanitize_command(command)
-        logging.info(f"Executing command: {sanitized_command}")
+        if WAZUH_PASSWORD and WAZUH_PASSWORD in command:
+            logging.info("Executing sensitive command: [command details redacted]")
+        else:
+            logging.info(f"Executing command: {sanitized_command}")
     except ValueError as e:
         logging.error(f"Failed to sanitize command: {e}")
         raise


### PR DESCRIPTION
Potential fix for [https://github.com/SnickerSec/wazuh-upgrader/security/code-scanning/6](https://github.com/SnickerSec/wazuh-upgrader/security/code-scanning/6)

To fix this issue, the best approach is to avoid logging commands (and their outputs) when they contain embedded sensitive information such as credentials, even if those credentials are "sanitized." Instead, log only safe, generic messages indicating a command execution, or specifically redact/removal logging for commands detected to contain credentials (e.g., if the command includes `WAZUH_PASSWORD`, even after attempted redaction). This ensures that passwords or other secrets never appear—even in partial or incorrectly sanitized form—within log files. The fix will modify the log message in `run_command()` by logging only the command name, or if redaction was necessary, only logging that a sensitive command was executed (without the command details). Only the shown region of `upgrade_wazuh.py` will be changed; e.g., only the lines of `run_command` that are provided.

You do not need to introduce new imports; Python standard logging suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
