### PR TITLE
Fix CVE-2026-21441: Update urllib3 to secure version >=2.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lxml==5.3.0
 requests==2.32.4
 python-dotenv==1.0.0
 typing-extensions>=4.7.1
+urllib3>=2.6.3


### PR DESCRIPTION
- Addresses high severity vulnerability in urllib3 2.6.1
- CVE-2026-21441: Decompression-bomb safeguard bypass
- Explicitly pin urllib3>=2.6.3 to ensure secure version